### PR TITLE
[MOG-11]: Download Stream Fixes

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
   "website": "https://www.mogz.studio",
   "packageManager": "pnpm@10.26.0",
   "engines": {
-    "node": "20.x"
+    "node": ">=20.0.0"
   },
   "scripts": {
     "dev": "next dev --turbopack",

--- a/src/app/api/download/info/route.test.ts
+++ b/src/app/api/download/info/route.test.ts
@@ -1,0 +1,128 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { POST } from './route';
+import { NextRequest } from 'next/server';
+import { fetchSanityData } from '@/lib/sanity/client';
+
+// Mock Dependencies
+vi.mock('@/lib/sanity/client', () => ({
+  fetchSanityData: vi.fn(),
+}));
+
+vi.mock('@/lib/env', () => ({
+  ENCRYPTION_KEY: 'test-key',
+}));
+
+describe('POST /api/download/info', () => {
+  const mockFetchSanity = vi.mocked(fetchSanityData);
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    global.fetch = vi.fn();
+  });
+
+  const createRequest = (body: FormData) =>
+    new NextRequest('http://localhost/api/download/info', {
+      method: 'POST',
+      body,
+    });
+
+  it('should calculate size using correct sample ratio', async () => {
+    // Mock Sanity Data: 20 items, each 1000 bytes
+    const mockItems = Array.from({ length: 20 }, (_, i) => ({
+      url: `http://cdn.sanity.io/img${i}.jpg`,
+      size: 1000,
+    }));
+
+    mockFetchSanity.mockResolvedValue({
+      title: 'Test Collection',
+      gallery: mockItems,
+    });
+
+    // Mock HEAD requests: Real size is 500 bytes (0.5 ratio)
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      headers: { get: () => '500' },
+    });
+
+    const formData = new FormData();
+    formData.append('slug', 'test-slug');
+
+    const res = await POST(createRequest(formData));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(data.count).toBe(20);
+    // Logic:
+    // Ratio = 500 / 1000 = 0.5
+    // Total Size = (20 * 1000 * 0.5) + Overhead(approx)
+    // 10,000 + Overhead.
+    // We just verify it's less than raw size (20000)
+    expect(data.size).toBeLessThan(20000);
+    expect(data.size).toBeGreaterThan(10000);
+  });
+
+  it('should retry HEAD requests on failure', async () => {
+    const mockItems = [{ url: 'http://cdn.sanity.io/img1.jpg', size: 1000 }];
+    mockFetchSanity.mockResolvedValue({
+      title: 'Retry Test',
+      gallery: mockItems,
+    });
+
+    // Mock Fetch: Fail twice, succeed third time
+    const fetchMock = global.fetch as any;
+    fetchMock
+      .mockRejectedValueOnce(new Error('Fail 1'))
+      .mockRejectedValueOnce(new Error('Fail 2'))
+      .mockResolvedValue({
+        ok: true,
+        headers: { get: () => '500' },
+      });
+
+    const formData = new FormData();
+    formData.append('slug', 'retry-test');
+
+    await POST(createRequest(formData));
+
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('should include User-Agent in HEAD requests', async () => {
+    mockFetchSanity.mockResolvedValue({
+      title: 'UA Test',
+      gallery: [{ url: 'http://cdn.sanity.io/img1.jpg', size: 1000 }],
+    });
+    (global.fetch as any).mockResolvedValue({
+      ok: true,
+      headers: { get: () => '500' },
+    });
+
+    const formData = new FormData();
+    formData.append('slug', 'ua-test');
+
+    await POST(createRequest(formData));
+
+    const calls = (global.fetch as any).mock.calls;
+    const headers = calls[0][1].headers;
+    expect(headers['User-Agent']).toBeDefined();
+    expect(headers['User-Agent']).toContain('Mozilla');
+  });
+
+  it('should return null (ratio 1) if all HEAD requests fail', async () => {
+    mockFetchSanity.mockResolvedValue({
+      title: 'Fail Test',
+      gallery: [{ url: 'http://cdn.sanity.io/img1.jpg', size: 1000 }],
+    });
+    // Always fail
+    (global.fetch as any).mockResolvedValue({ ok: false, status: 500 });
+
+    const formData = new FormData();
+    formData.append('slug', 'fail-test');
+
+    const res = await POST(createRequest(formData));
+    const data = await res.json();
+
+    expect(res.status).toBe(200);
+    expect(typeof data.size).toBe('number');
+    expect(data.size).toBeGreaterThan(1000);
+  });
+});

--- a/src/app/api/download/info/route.ts
+++ b/src/app/api/download/info/route.ts
@@ -88,12 +88,12 @@ export async function POST(req: NextRequest) {
           }
 
           const res = await fetch(item.url, { method: 'HEAD' });
-          if (!res.ok) return;
+          if (!res.ok) return null;
           const cl = res.headers.get('content-length');
           if (cl) {
-            totalSampleSizeSanity += item.size;
-            totalSampleSizeReal += parseInt(cl, 10);
+            return { sanity: item.size, real: parseInt(cl, 10) };
           }
+          return null;
         } catch (e) {
           console.warn('[Info] HEAD failed for sample:', e);
         }

--- a/src/app/api/download/info/route.ts
+++ b/src/app/api/download/info/route.ts
@@ -6,6 +6,7 @@ import {
 } from '@/lib/sanity/queries';
 import CryptoJS from 'crypto-js';
 import { ENCRYPTION_KEY } from '@/lib/env';
+import { Buffer } from 'buffer';
 
 export async function POST(req: NextRequest) {
   try {
@@ -119,6 +120,7 @@ export async function POST(req: NextRequest) {
           return null;
         } catch (e: any) {
           console.warn(`[Info] HEAD error for sample: ${e.message}`);
+          return null;
         }
       }),
     );

--- a/src/app/api/download/info/route.ts
+++ b/src/app/api/download/info/route.ts
@@ -1,0 +1,138 @@
+import { NextRequest, NextResponse } from 'next/server';
+import { fetchSanityData } from '@/lib/sanity/client';
+import {
+  getDownloadGalleryBySlug,
+  getDownloadGalleryById,
+} from '@/lib/sanity/queries';
+import CryptoJS from 'crypto-js';
+import { ENCRYPTION_KEY } from '@/lib/env';
+
+export async function POST(req: NextRequest) {
+  try {
+    const formData = await req.formData();
+    const collectionId = formData.get('collectionId') as string;
+    const slug = formData.get('slug') as string;
+    const isPrivate = formData.get('isPrivate') === 'true';
+
+    if ((isPrivate && !collectionId) || (!isPrivate && !slug)) {
+      return NextResponse.json(
+        { message: 'Missing identifier' },
+        { status: 400 },
+      );
+    }
+
+    // AUTH CHECK FOR PRIVATE COLLECTIONS
+    if (isPrivate) {
+      const token = req.cookies.get('collectionAccess')?.value;
+      if (!token)
+        return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+
+      try {
+        const bytes = CryptoJS.AES.decrypt(token, ENCRYPTION_KEY);
+        const decryptedData = JSON.parse(bytes.toString(CryptoJS.enc.Utf8));
+        if (decryptedData.uniqueId !== collectionId)
+          throw new Error('Invalid token');
+      } catch (error) {
+        return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
+      }
+    }
+
+    // 1. Fetch Metadata and Items
+    let title = 'Collection';
+    let items: { url: string; size: number }[] = [];
+
+    if (isPrivate) {
+      const data = await fetchSanityData(getDownloadGalleryById, {
+        id: collectionId,
+      });
+      if (data) {
+        items = data.gallery || [];
+        title = data.title || 'Collection';
+      }
+    } else {
+      const data = await fetchSanityData(getDownloadGalleryBySlug, { slug });
+      if (data) {
+        items = data.gallery;
+        title = data.title;
+      }
+    }
+
+    if (!items || items.length === 0) {
+      return NextResponse.json(null, { status: 404 });
+    }
+
+    // 2. Calculate Correction Ratio (Sample ~3 images)
+    // Sanity metadata size = Source file size.
+    // Sanity CDN URL = Often optimized/compressed (WebP, etc) => Smaller.
+    // We fetch HEAD for a few items to get the REAL download size.
+    const sampleSize = Math.min(items.length, 5);
+    const sampleIndices = new Set<number>();
+    while (sampleIndices.size < sampleSize) {
+      sampleIndices.add(Math.floor(Math.random() * items.length));
+    }
+
+    let totalSampleSizeSanity = 0;
+    let totalSampleSizeReal = 0;
+
+    const samples = Array.from(sampleIndices).map((idx) => items[idx]);
+    await Promise.all(
+      samples.map(async (item) => {
+        try {
+          const res = await fetch(item.url, { method: 'HEAD' });
+          const cl = res.headers.get('content-length');
+          if (cl) {
+            totalSampleSizeSanity += item.size;
+            totalSampleSizeReal += parseInt(cl, 10);
+          }
+        } catch (e) {
+          console.warn('[Info] HEAD failed for sample:', e);
+        }
+      }),
+    );
+
+    // Default to 1 (no correction) if sampling fails/empty
+    const ratio =
+      totalSampleSizeSanity > 0
+        ? totalSampleSizeReal / totalSampleSizeSanity
+        : 1;
+
+    console.log(
+      `[Info] Size Correction: Sanity=${totalSampleSizeSanity}, Real=${totalSampleSizeReal}, Ratio=${ratio.toFixed(2)}`,
+    );
+
+    // 3. Recalculate Total Size with Ratio
+    let size = 0;
+    const EOCD_SIZE = 22;
+    const ALLOWED_EXTS = ['jpg', 'jpeg', 'png', 'webp', 'gif', 'svg'];
+
+    items.forEach((item, idx) => {
+      const urlPath = item.url.split('?')[0];
+      const parts = urlPath.split('.');
+      const extension =
+        parts.length > 1 ? parts.pop()?.toLowerCase() || '' : '';
+      const validExtension = ALLOWED_EXTS.includes(extension)
+        ? extension
+        : 'jpg';
+
+      const cleanName = title.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+      const filename = `${cleanName}-${idx + 1}.${validExtension}`;
+      const nameLen = Buffer.byteLength(filename);
+
+      // Apply ratio to data size
+      const data = Math.floor(item.size * ratio);
+
+      const overhead = 30 + nameLen + 16 + 46 + nameLen;
+      size += overhead + data;
+    });
+
+    size += EOCD_SIZE;
+
+    return NextResponse.json({ size, count: items.length });
+  } catch (error: any) {
+    console.error('[API] Info Error:', error);
+    return NextResponse.json(
+      { message: 'Internal Server Error' },
+      { status: 500 },
+    );
+  }
+}

--- a/src/app/api/download/info/route.ts
+++ b/src/app/api/download/info/route.ts
@@ -72,9 +72,6 @@ export async function POST(req: NextRequest) {
       sampleIndices.add(randomIdx);
     }
 
-    let totalSampleSizeSanity = 0;
-    let totalSampleSizeReal = 0;
-
     const samples = Array.from(sampleIndices).map((idx) => items[idx]);
     const results = await Promise.all(
       samples.map(async (item) => {
@@ -126,12 +123,18 @@ export async function POST(req: NextRequest) {
       }),
     );
     // Accumulate results
-    results.forEach((result) => {
-      if (result?.sanity && result?.real) {
-        totalSampleSizeSanity += result.sanity;
-        totalSampleSizeReal += result.real;
-      }
-    });
+    const { sanity, real } = results.reduce(
+      (acc: { sanity: number; real: number }, result) => {
+        if (result && result.sanity && result.real) {
+          acc.sanity += result.sanity;
+          acc.real += result.real;
+        }
+        return acc;
+      },
+      { sanity: 0, real: 0 },
+    );
+    const totalSampleSizeSanity = sanity;
+    const totalSampleSizeReal = real;
 
     // Default to 1 (no correction) if sampling fails/empty
     const ratio =

--- a/src/app/api/download/info/route.ts
+++ b/src/app/api/download/info/route.ts
@@ -88,6 +88,7 @@ export async function POST(req: NextRequest) {
           }
 
           const res = await fetch(item.url, { method: 'HEAD' });
+          if (!res.ok) return;
           const cl = res.headers.get('content-length');
           if (cl) {
             totalSampleSizeSanity += item.size;

--- a/src/app/api/download/stream/route.test.ts
+++ b/src/app/api/download/stream/route.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
 import { POST } from './route';
 import { NextRequest } from 'next/server';
 import fs from 'fs';
-import { Readable } from 'stream';
+import { Readable, PassThrough } from 'stream';
 
 // Mocks
 vi.mock('@/lib/sanity/client', () => ({
@@ -16,7 +16,7 @@ vi.mock('@/lib/env', () => ({
 vi.mock('archiver', () => {
   return {
     default: vi.fn(() => ({
-      pipe: vi.fn(),
+      pipe: vi.fn((dest) => dest), // Pipe returns destination (PassThrough)
       append: vi.fn((source, name) => {
         if (source && typeof source.resume === 'function') {
           source.resume(); // Consume stream so 'finished' resolves
@@ -43,10 +43,16 @@ vi.mock('fs', async (importOriginal) => {
   const mockMkdtempSync = vi.fn((p) => p + 'unique');
   const mockCreateWriteStream = vi.fn(() => ({
     on: vi.fn((event, cb) => {
-      if (event === 'close') cb();
+      // Use setTimeout to simulate async file writing
+      setTimeout(cb, 10);
+      return this; // chaining
     }),
+    once: vi.fn(),
+    emit: vi.fn(),
     write: vi.fn(),
     end: vi.fn(),
+    removeListener: vi.fn(),
+    listenerCount: vi.fn().mockReturnValue(0),
   }));
   const mockCreateReadStream = vi.fn(() => ({
     on: vi.fn(),
@@ -97,7 +103,7 @@ describe('POST /api/download/stream', () => {
   beforeEach(() => {
     vi.clearAllMocks();
     // Default mocks
-    (fs.existsSync as any).mockReturnValue(false); // No cache hit
+    (fs.existsSync as any).mockReturnValue(false); // No cache hit by default
     (fs.statSync as any).mockReturnValue({ mtimeMs: Date.now(), size: 1024 });
     (fs.promises.readdir as any).mockResolvedValue([]);
     (fs.promises.stat as any).mockResolvedValue({ mtimeMs: Date.now() });
@@ -114,6 +120,7 @@ describe('POST /api/download/stream', () => {
 
   afterEach(() => {
     vi.restoreAllMocks();
+    vi.spyOn(Math, 'random').mockRestore(); // Restore Random if spied
   });
 
   it('should validate email requirement', async () => {
@@ -175,6 +182,9 @@ describe('POST /api/download/stream', () => {
   });
 
   it('should retry rename on failure (Windows Lock Simulation)', async () => {
+    // Mock clean run to avoid interference from random cleanup
+    vi.spyOn(Math, 'random').mockReturnValue(0.9); // Skip cleanup
+
     mockFetchSanity.mockResolvedValue({
       title: 'Collection Retry',
       gallery: [{ url: 'http://cdn.sanity.io/img1.jpg' }],
@@ -188,19 +198,30 @@ describe('POST /api/download/stream', () => {
       body: formData,
     });
 
-    // Mock rename sequence: Error, Error, Success
+    // Mock rename sequence explicitly
     const renameMock = vi.mocked(fs.promises.rename);
-    renameMock
-      .mockRejectedValueOnce(new Error('EPERM'))
-      .mockRejectedValueOnce(new Error('EBUSY'))
-      .mockResolvedValue(undefined as never); // Success eventually
+    renameMock.mockReset(); // Clear previous implementations
+
+    let calls = 0;
+    renameMock.mockImplementation(async () => {
+      calls++;
+      if (calls <= 2) throw new Error('Simulated Fail');
+      return undefined;
+    });
 
     await POST(req);
 
-    expect(renameMock).toHaveBeenCalledTimes(3);
+    // Wait for the background process (rename happens in background after stream)
+    await new Promise((r) => setTimeout(r, 1000));
+
+    expect(calls).toBeGreaterThanOrEqual(3);
+    expect(renameMock).toHaveBeenCalledTimes(calls);
   });
 
   it('should cleanup old files on successful generation logic', async () => {
+    // FORCE cleanup to run
+    vi.spyOn(Math, 'random').mockReturnValue(0.05);
+
     // This tests that our cleanup logic is triggered
     mockFetchSanity.mockResolvedValue({
       title: 'Collection Cleanup',
@@ -224,6 +245,9 @@ describe('POST /api/download/stream', () => {
     }); // > 1 hour old
 
     await POST(req);
+
+    // Wait for cleanup background task
+    await new Promise((r) => setTimeout(r, 100));
 
     // Verify cleanup was attempted
     expect(fs.promises.readdir).toHaveBeenCalled();

--- a/src/app/api/download/stream/route.ts
+++ b/src/app/api/download/stream/route.ts
@@ -1,3 +1,14 @@
+// Suppress unhandled rejections in development
+if (process.env.NODE_ENV === 'development') {
+  process.on('unhandledRejection', (reason: any) => {
+    if (reason?.name === 'AbortError' || reason?.message?.includes('abort')) {
+      // Ignore abort-related rejections
+      return;
+    }
+    console.error('Unhandled Rejection:', reason);
+  });
+}
+
 import { NextRequest, NextResponse } from 'next/server';
 import archiver from 'archiver';
 import { fetchSanityData } from '@/lib/sanity/client';
@@ -10,7 +21,7 @@ import path from 'path';
 import os from 'os';
 import CryptoJS from 'crypto-js';
 
-import { Readable } from 'stream';
+import { Readable, PassThrough } from 'stream';
 import { finished } from 'stream/promises';
 import { ENCRYPTION_KEY } from '@/lib/env';
 
@@ -19,9 +30,6 @@ import { ENCRYPTION_KEY } from '@/lib/env';
  */
 const cleanupOldFiles = async (dir: string) => {
   try {
-    // Determine strict debounce: unique touch of lock file at START of attempt
-    // This ensures that even if readdir fails or process crashes, we don't retry immediately.
-
     const files = await fs.promises.readdir(dir);
     const now = Date.now();
     await Promise.all(
@@ -44,7 +52,6 @@ const cleanupOldFiles = async (dir: string) => {
 
 /**
  * Manual Iterator to Stream converter
- * This is more robust than Readable.toWeb in some Next.js environments
  */
 function iteratorToStream(iterator: any) {
   return new ReadableStream({
@@ -68,13 +75,10 @@ function iteratorToStream(iterator: any) {
   });
 }
 
-async function* nodeStreamToIterator(
-  stream: fs.ReadStream,
-  signal?: AbortSignal,
-) {
+// Convert Node stream to async iterator for Next.js response
+async function* nodeStreamToIterator(stream: Readable, signal?: AbortSignal) {
   try {
     if (signal?.aborted) return;
-
     for await (const chunk of stream) {
       if (signal?.aborted) {
         stream.destroy();
@@ -87,13 +91,82 @@ async function* nodeStreamToIterator(
   }
 }
 
+// Helper to calculate exact ZIP size for Content-Length
+function calculateZipSize(items: any[], title: string): number {
+  let size = 0;
+  const EOCD_SIZE = 22;
+
+  const ALLOWED_EXTS = ['jpg', 'jpeg', 'png', 'webp', 'gif', 'svg'];
+
+  items.forEach((item, idx) => {
+    // Replicate filename logic from POST
+    const urlPath = item.url.split('?')[0];
+    const parts = urlPath.split('.');
+    const extension = parts.length > 1 ? parts.pop().toLowerCase() : '';
+    const validExtension = ALLOWED_EXTS.includes(extension) ? extension : 'jpg';
+
+    // Must match POST logic exactly
+    const cleanName = title.replace(/[^a-z0-9]/gi, '_').toLowerCase();
+    const filename = `${cleanName}-${idx + 1}.${validExtension}`;
+    const nameLen = Buffer.byteLength(filename);
+
+    const data = item.size;
+
+    // Overhead for STORE (Level 0) + Streaming (Data Descriptor) + No Extra Fields
+    // Local Header: 30 + name + 0
+    // Data Descriptor: 16
+    // Central Header: 46 + name + 0
+    const overhead = 30 + nameLen + 16 + 46 + nameLen;
+
+    size += overhead + data;
+  });
+
+  return size + EOCD_SIZE;
+}
+
+function createZeroStream(size: number) {
+  let remaining = size;
+  return new Readable({
+    read(this: Readable, n: number) {
+      const chunk = remaining > 65536 ? 65536 : remaining;
+      if (remaining <= 0) {
+        this.push(null);
+      } else {
+        this.push(Buffer.alloc(chunk, 0));
+        remaining -= chunk;
+      }
+    },
+  });
+}
+
+export async function GET(req: NextRequest) {
+  return handleDownload(req);
+}
+
 export async function POST(req: NextRequest) {
+  return handleDownload(req);
+}
+
+async function handleDownload(req: NextRequest) {
   try {
-    const formData = await req.formData();
-    const collectionId = formData.get('collectionId') as string;
-    const slug = formData.get('slug') as string;
-    const email = formData.get('email') as string;
-    const isPrivate = formData.get('isPrivate') === 'true';
+    let collectionId = '';
+    let slug = '';
+    let email = '';
+    let isPrivate = false;
+
+    if (req.method === 'GET') {
+      const { searchParams } = req.nextUrl;
+      collectionId = searchParams.get('collectionId') || '';
+      slug = searchParams.get('slug') || '';
+      email = searchParams.get('email') || '';
+      isPrivate = searchParams.get('isPrivate') === 'true';
+    } else {
+      const formData = await req.formData();
+      collectionId = formData.get('collectionId') as string;
+      slug = formData.get('slug') as string;
+      email = formData.get('email') as string;
+      isPrivate = formData.get('isPrivate') === 'true';
+    }
 
     // ... Validation Logic ...
     if (!email)
@@ -108,29 +181,22 @@ export async function POST(req: NextRequest) {
     // AUTH CHECK FOR PRIVATE COLLECTIONS
     if (isPrivate) {
       const token = req.cookies.get('collectionAccess')?.value;
-
-      if (!token) {
+      if (!token)
         return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
-      }
 
       try {
         const bytes = CryptoJS.AES.decrypt(token, ENCRYPTION_KEY);
         const decryptedData = JSON.parse(bytes.toString(CryptoJS.enc.Utf8));
-
-        if (decryptedData.uniqueId !== collectionId) {
+        if (decryptedData.uniqueId !== collectionId)
           throw new Error('Invalid token');
-        }
       } catch (error) {
         return NextResponse.json({ message: 'Unauthorized' }, { status: 401 });
       }
     }
 
-    // 1. Fetch Metadata (Title) - ALWAYS fetch to ensure correct naming!
-    // We do this lightweight fetch even if we might hit cache later.
+    // 1. Fetch Metadata and Items
     let title = 'Collection';
     let items: { url: string; size: number }[] = [];
-
-    // Sanitize slug/id
 
     if (isPrivate) {
       const data = await fetchSanityData(getDownloadGalleryById, {
@@ -155,307 +221,254 @@ export async function POST(req: NextRequest) {
       );
     }
 
-    // 2. Determine Cache Key (Filename)
-    // Use a hash of the content (items) + identifier to ensure invalidation when content changes
-    // This resolves the issue of serving stale zips if Sanity data updates
+    // 2. Determine Cache Key
     const contentHash = CryptoJS.MD5(JSON.stringify(items)).toString();
     const safeId = CryptoJS.MD5(collectionId || slug).toString();
-
-    // stable cache key dependent on content version, ensuring safeId is used
     const cacheKey = isPrivate
       ? `priv_${safeId}_${contentHash}`
       : `pub_${safeId}_${contentHash}`;
 
     const tempDir = os.tmpdir();
-    // NO Date.now() here -> allows caching
-    const tempFilename = `mogz_${cacheKey}.zip`; // cacheKey is already hex, so it's safe
+    const tempFilename = `mogz_${cacheKey}.zip`;
     const tempFilePath = path.join(tempDir, tempFilename);
+    const downloadName = `[MOGZ] ${title.replace(/[^a-z0-9]/gi, '_').toLowerCase()}.zip`;
 
     console.log(`[Stream] Request for: ${title} (${tempFilename})`);
 
-    // 3. Check Cache (Hit or Miss?)
-    let useCache = false;
+    // 3. Check Cache
     try {
       if (fs.existsSync(tempFilePath)) {
         const stats = fs.statSync(tempFilePath);
         const age = Date.now() - stats.mtimeMs;
-        // Check if file is valid (not empty and < 1 hour old)
         if (stats.size > 0 && age < 3600000) {
           console.log(
-            `[Cache] HIT: Available (${(stats.size / 1024 / 1024).toFixed(
-              2,
-            )} MB)`,
+            `[Cache] HIT: Available (${(stats.size / 1024 / 1024).toFixed(2)} MB)`,
           );
-          useCache = true;
+
+          const fileStream = fs.createReadStream(tempFilePath);
+          const stream = iteratorToStream(
+            nodeStreamToIterator(fileStream, req.signal),
+          );
+
+          return new NextResponse(stream as any, {
+            headers: {
+              'Content-Type': 'application/zip',
+              'Content-Disposition': `attachment; filename="${downloadName}"`,
+              'Content-Length': stats.size.toString(),
+              'Accept-Ranges': 'bytes',
+              'Cache-Control': 'no-cache',
+            },
+          });
         }
       }
     } catch (e) {
       console.warn('[Cache] Check failed, forcing regeneration.');
     }
 
-    // 4. Generate if needed (Blocking Operation)
-    if (!useCache) {
-      // 🧹 Cleanup Debounce: Check lock file to avoid concurrent scans (throttle to 5 mins)
-      const lockPath = path.join(tempDir, '.cleanup_lock');
-      try {
-        let shouldRun = true;
-        if (fs.existsSync(lockPath)) {
-          const stats = fs.statSync(lockPath);
-          // If lock file is fresh (< 5 mins), skip cleanup
-          if (Date.now() - stats.mtimeMs < 300000) shouldRun = false;
-        }
+    // 4. Stream Generation (Simultaneous Response + Cache Write)
+    // Cleanup old files first (maintenance)
+    try {
+      if (Math.random() < 0.1) cleanupOldFiles(tempDir).catch(console.error);
+    } catch {}
 
-        if (shouldRun) {
-          // FIX: Update lock file ONLY after successful cleanup to prevent blocking if cleanup fails
-          cleanupOldFiles(tempDir)
-            .then(() => {
+    const uniqueGenDir = fs.mkdtempSync(path.join(tempDir, 'gen-'));
+    const uniqueGenPath = path.join(uniqueGenDir, 'partial.zip');
+
+    // Create the Archive
+    const archive = archiver('zip', {
+      zlib: { level: 0 },
+      forceZip64: false,
+      highWaterMark: 1024 * 1024,
+    });
+
+    const passThrough = new PassThrough();
+    archive.pipe(passThrough);
+
+    // Fork stream: 1 to File (Cache), 1 to Response
+    const fileWritePromise = new Promise<void>((resolve, reject) => {
+      const fileOutput = fs.createWriteStream(uniqueGenPath);
+      fileOutput.on('close', resolve);
+      fileOutput.on('error', reject);
+      passThrough.pipe(fileOutput); // Pipe data to file
+    });
+
+    // We also need to handle the response stream.
+    // Since PassThrough is a Readable, we can use it for response.
+    // BUT piping to multiple destinations?
+    // PassThrough.pipe(fileOutput) returns fileOutput.
+    // We need another branch.
+    // The standard way is: source.pipe(dest1); source.pipe(dest2);
+    // But in Node streams, piping consumes? No, one readable can pipe to multiple writables.
+    // However, for the Response, we need an Iterator/ReadableStream.
+
+    // Strategy:
+    // archive -> passThrough
+    // passThrough.pipe(fs.createWriteStream(...))
+    // passThrough is also passed to iteratorToStream for Response.
+
+    // Note: Request abortion should abort archive to stop processing.
+    if (req.signal.aborted) {
+      throw new Error('Aborted');
+    }
+    const abortHandler = () => {
+      console.warn('[Stream] Aborted by client');
+      archive.abort();
+    };
+    req.signal.addEventListener('abort', abortHandler);
+
+    // Processing Logic
+    const processingPromise = (async () => {
+      try {
+        const BATCH_SIZE = 3;
+        let successCount = 0;
+        const ALLOWED_EXTS = ['jpg', 'jpeg', 'png', 'webp', 'gif', 'svg'];
+        const successfulItems: any[] = []; // ⭐ Track what actually gets added
+
+        for (let i = 0; i < items.length; i += BATCH_SIZE) {
+          if (req.signal.aborted) throw new Error('Aborted');
+          const batch = items.slice(i, i + BATCH_SIZE);
+
+          const results = await Promise.allSettled(
+            batch.map(async (img: any, idx) => {
               try {
-                fs.writeFileSync(lockPath, '');
-              } catch (lockErr) {
-                console.warn('[Cleanup] Failed to update lock file:', lockErr);
-              }
-            })
-            .catch(console.error);
-        }
-      } catch (e) {
-        // Fallback: random execute if lock check fails
-        if (Math.random() < 0.1) cleanupOldFiles(tempDir).catch(console.error);
-      }
+                // ⭐ Wrap everything in try-catch
+                if (req.signal.aborted) return null;
 
-      // FIX RACE CONDITION: Use mkdtemp for unique generation path
-      const uniqueGenDir = fs.mkdtempSync(path.join(tempDir, 'gen-'));
-      const uniqueGenPath = path.join(uniqueGenDir, 'partial.zip');
+                // Validation & Sanitization Logic
+                const urlPath = img.url.split('?')[0];
+                const parts = urlPath.split('.');
+                const extension =
+                  parts.length > 1 ? parts.pop().toLowerCase() : '';
+                const validExtension = ALLOWED_EXTS.includes(extension)
+                  ? extension
+                  : 'jpg';
 
-      try {
-        console.log(`[Disk] Generating new ZIP: ${uniqueGenPath}`);
-
-        const output = fs.createWriteStream(uniqueGenPath);
-        const archive = archiver('zip', {
-          zlib: { level: 0 }, // Store only
-          forceZip64: false,
-          highWaterMark: 1024 * 1024, // FIX: Apply backpressure limit (1MB) to prevent excessive buffering
-        });
-
-        // Handle Abort Signal
-        if (req.signal.aborted) {
-          throw new Error('Aborted');
-        }
-        const abortHandler = () => {
-          console.warn('[Stream] Aborted by client');
-          archive.abort();
-        };
-        req.signal.addEventListener('abort', abortHandler);
-
-        // Wrap generation in a Promise we can await
-        const generationPromise = new Promise<void>((resolve, reject) => {
-          output.on('close', resolve);
-          output.on('error', (err) =>
-            reject(new Error(`Write Error: ${err.message}`)),
-          );
-          archive.on('error', (err) =>
-            reject(new Error(`Archive Error: ${err.message}`)),
-          );
-          archive.pipe(output);
-        });
-
-        // Start Async Processing (captured in promise)
-        const processingPromise = (async () => {
-          try {
-            const BATCH_SIZE = 3; // Reduced to 3 to strictly limit memory buffering with mixed stream speeds
-            let successCount = 0;
-            const ALLOWED_EXTS = ['jpg', 'jpeg', 'png', 'webp', 'gif', 'svg']; // Strict whitelist
-            for (let i = 0; i < items.length; i += BATCH_SIZE) {
-              if (req.signal.aborted) throw new Error('Aborted');
-
-              const batch = items.slice(i, i + BATCH_SIZE);
-              const buffers = await Promise.all(
-                batch.map(async (img: any, idx) => {
-                  try {
-                    const urlPath = img.url.split('?')[0]; // Strip query params
-                    const parts = urlPath.split('.');
-                    const extension =
-                      parts.length > 1 ? parts.pop().toLowerCase() : '';
-                    const validExtension = ALLOWED_EXTS.includes(extension)
-                      ? extension
-                      : 'jpg';
-
-                    // FIX SSRF: Validate URL origin using robust parsing BEFORE fetch
-                    try {
-                      const urlObj = new URL(img.url);
-                      if (urlObj.hostname !== 'cdn.sanity.io') {
-                        console.warn(
-                          `[Skip] Invalid image URL domain: ${img.url}`,
-                        );
-                        return null;
-                      }
-                    } catch {
-                      console.warn(`[Skip] Malformed URL: ${img.url}`);
-                      return null;
-                    }
-
-                    // Sanitize filename inside ZIP
-                    const cleanName = title
-                      .replace(/[^a-z0-9]/gi, '_')
-                      .toLowerCase();
-                    const filename = `${cleanName}-${i + idx + 1}.${validExtension}`;
-
-                    const res = await fetch(img.url, { signal: req.signal });
-                    if (!res.ok) {
-                      console.warn(
-                        `[Stream] Fetch failed (${res.status}): ${img.url}`,
-                      );
-                      return null;
-                    }
-
-                    // FIX DoS: Pipe stream directly to archiver to avoid loading full image into RAM
-                    if (res.body) {
-                      // @ts-ignore - Readable.fromWeb is available in Node 18+ environment of Next.js
-                      const stream = Readable.fromWeb(res.body);
-                      return { name: filename, stream };
-                    }
-                    return null;
-                  } catch (fetchErr) {
-                    console.error(
-                      `[Stream] URL processing error: ${img.url}`,
-                      fetchErr,
-                    );
-                    return null;
-                  }
-                }),
-              );
-
-              const activeStreams = buffers
-                .map((f) => f?.stream)
-                .filter(Boolean) as Readable[];
-
-              for (const file of buffers) {
-                if (file?.stream) {
-                  archive.append(file.stream, { name: file.name });
-                  successCount++;
+                try {
+                  const urlObj = new URL(img.url);
+                  if (urlObj.hostname !== 'cdn.sanity.io') return null;
+                } catch {
+                  return null;
                 }
+
+                const cleanName = title
+                  .replace(/[^a-z0-9]/gi, '_')
+                  .toLowerCase();
+                const filename = `${cleanName}-${i + idx + 1}.${validExtension}`;
+
+                const res = await fetch(img.url, {
+                  signal: req.signal,
+                });
+
+                if (!res.ok) {
+                  console.warn(
+                    `[Stream] HTTP ${res.status} for ${filename}, skipping.`,
+                  );
+                  return null;
+                }
+
+                if (res.body) {
+                  // @ts-ignore
+                  const stream = Readable.fromWeb(res.body);
+                  return { name: filename, stream, item: img }; // ⭐ Include original item
+                }
+                return null;
+              } catch (e: any) {
+                // ⭐ Catch ALL errors including ResponseAborted
+                if (req.signal.aborted) return null; // Silent return on abort
+                console.warn(`[Stream] Error fetching image:`, e.message);
+                return null;
               }
+            }),
+          );
 
-              // Wait for the last stream in batch to be fully consumed (written)
-              // This strictly serializes transmission of batches so we don't buffer next batch in RAM
-              if (activeStreams.length > 0) {
-                const lastStream = activeStreams[activeStreams.length - 1];
-                await finished(lastStream).catch(() => {});
-              }
+          // Extract successful results
+          const buffers = results
+            .filter((result) => result.status === 'fulfilled' && result.value)
+            .map((result: any) => result.value);
+
+          // Append valid streams
+          for (const file of buffers) {
+            if (file?.stream) {
+              archive.append(file.stream, { name: file.name });
+              successfulItems.push(file.item); // ⭐ Track successful items
+              successCount++;
             }
-
-            if (successCount === 0) {
-              throw new Error(
-                'No valid files could be downloaded for the archive',
-              );
-            }
-
-            await archive.finalize();
-
-            // FIX: Validate final ZIP size (headers + content). Empty zip is ~22 bytes.
-            // Warning if < 500 bytes (very small archive).
-            // Warning if < expected min size (headers + ~100 bytes per file).
-            const minExpectedSize = successCount * 100;
-            if (archive.pointer() < minExpectedSize) {
-              console.warn(
-                `[Stream] Archive size (${archive.pointer()} bytes) smaller than expected for ${successCount} files.`,
-              );
-            }
-          } catch (err) {
-            console.error('[Stream] Archive Gen Failed:', err);
-            archive.abort();
-            throw err; // Propagate error to Promise.all
           }
-        })();
 
-        // WAIT for BOTH processing (to catch fast errors) and generation (write completion)
-        await Promise.all([processingPromise, generationPromise]);
+          // Wait for last stream in batch
+          if (buffers.length > 0) {
+            const lastStream = buffers[buffers.length - 1].stream;
+            await finished(lastStream).catch(() => {});
+          }
+        }
 
+        if (successCount === 0) throw new Error('No valid files');
+
+        // ⭐ Log discrepancy
+        if (successfulItems.length < items.length) {
+          console.warn(
+            `[Stream] Only ${successfulItems.length}/${items.length} images added to zip`,
+          );
+        }
+
+        await archive.finalize();
+      } catch (err: any) {
+        if (err.message === 'Aborted' || req.signal.aborted) {
+          console.log('[Stream] Client aborted connection (expected behavior)');
+        } else {
+          console.error('[Stream] Processing failed:', err);
+        }
+        archive.abort();
+      }
+    })();
+
+    // Handle Cache Finalization (after stream ends)
+    // We don't await this for the response to start, but we should handle errors.
+    Promise.all([processingPromise, fileWritePromise])
+      .then(async () => {
+        // Rename logic (Windows retry)
         req.signal.removeEventListener('abort', abortHandler);
-
-        // Rename to final cache path with retry strategy for Windows file locking
-        // Windows rename might fail if file open or exists, so we try simple remove then rename
         const MAX_RETRIES = 3;
         let renamed = false;
-
-        // Optimizing retry with exponential backoff and lower base delay
         for (let i = 0; i < MAX_RETRIES; i++) {
           try {
             try {
               await fs.promises.access(tempFilePath);
               await fs.promises.unlink(tempFilePath);
             } catch {}
-
             await fs.promises.rename(uniqueGenPath, tempFilePath);
             renamed = true;
             break;
-          } catch (retryErr) {
-            // Exponential backoff: 50ms, 100ms, 200ms...
-            await new Promise((r) => setTimeout(r, 50 * Math.pow(2, i)));
+          } catch (e) {
+            await new Promise((r) => setTimeout(r, 100 * Math.pow(2, i)));
           }
         }
-
-        if (!renamed) {
-          console.error('[Stream] Failed to rename after retries, cleaning up');
-          throw new Error('File system contention prevented caching');
-        }
-
-        fs.rmSync(uniqueGenDir, { recursive: true, force: true }); // cleanup unique dir
-      } catch (err) {
-        console.error('[Stream] Generation/Rename Failed:', err);
-        // Guarantee cleanup of unique dir if ANYTHING fails (generation, write, abort, or rename)
+        if (renamed) fs.rmSync(uniqueGenDir, { recursive: true, force: true });
+      })
+      .catch((err) => {
+        console.error('[Stream] Background cache write failed:', err);
         try {
           if (fs.existsSync(uniqueGenPath)) fs.unlinkSync(uniqueGenPath);
           if (fs.existsSync(uniqueGenDir))
             fs.rmSync(uniqueGenDir, { recursive: true, force: true });
         } catch {}
+      });
 
-        return NextResponse.json(
-          { message: 'File generation failed' },
-          { status: 500 },
-        );
-      }
-    }
+    // If we MUST provide valid Content-Length for streaming:
+    const calculatedSize = calculateZipSize(items, title);
 
-    // 5. Check Mode
-    // If 'prepare' mode, return JSON success
-    const mode = formData.get('mode') as string;
-    if (mode === 'prepare') {
-      return NextResponse.json({ success: true, filename: tempFilename });
-    }
-
-    // 6. Serve the File (Download Mode)
-    const stats = fs.statSync(tempFilePath);
-    const fileStream = fs.createReadStream(tempFilePath);
-
-    let streamErrorOccurred = false;
-    fileStream.on('error', (err) => {
-      console.error('[Stream] Read error:', err);
-      streamErrorOccurred = true;
-      // Note: We cannot abort the HTTP response here if headers are already sent.
-      // The client will likely receive a partial/corrupt ZIP file.
-      fileStream.destroy(err); // Propagate error state
-    });
-
-    // Correct Filename using the Fetched Title
-    const downloadName = `[MOGZ] ${title
-      .replace(/[^a-z0-9]/gi, '_')
-      .toLowerCase()}.zip`;
-
-    console.log(`[Stream] Serving: ${downloadName}`);
-
-    // Robust Stream Conversion
-    // @ts-ignore - The iterator method is universally compatible with Next.js Response
-    const stream = iteratorToStream(
-      nodeStreamToIterator(fileStream, req.signal),
+    const responseStream = iteratorToStream(
+      nodeStreamToIterator(passThrough, req.signal),
     );
 
-    return new NextResponse(stream as any, {
+    return new NextResponse(responseStream as any, {
       headers: {
         'Content-Type': 'application/zip',
         'Content-Disposition': `attachment; filename="${downloadName}"`,
-        'Content-Length': stats.size.toString(), // We have exact size now!
-        'Accept-Ranges': 'bytes', // Resume support
+        // Content-Length removed - can't predict size when images might fail
+        'Accept-Ranges': 'none',
         'Cache-Control': 'no-cache',
+        Connection: 'close',
       },
     });
   } catch (error: any) {

--- a/src/app/api/download/stream/route.ts
+++ b/src/app/api/download/stream/route.ts
@@ -240,7 +240,9 @@ async function handleDownload(req: NextRequest) {
 
     // Fork stream: 1 to File (Cache), 1 to Response
     const fileWritePromise = new Promise<void>((resolve, reject) => {
-      const fileOutput = fs.createWriteStream(uniqueGenPath);
+      const fileOutput = fs.createWriteStream(uniqueGenPath, {
+        highWaterMark: 1024 * 1024,
+      });
       fileOutput.on('close', resolve);
       fileOutput.on('error', (err) => {
         archive.abort();

--- a/src/app/private/page.tsx
+++ b/src/app/private/page.tsx
@@ -7,7 +7,8 @@ import { fetchSanityData } from '@/lib/sanity/client';
 import { COLLECTION } from '@/lib/types';
 import PrivateGallery from '@/components/gallery/PrivateGallery';
 
-export const revalidate = 60;
+// export const revalidate = 60;
+export const dynamic = 'force-dynamic';
 
 const page = async (props: { searchParams: Promise<SearchParams> }) => {
   const searchParams = await props.searchParams;
@@ -20,7 +21,7 @@ const page = async (props: { searchParams: Promise<SearchParams> }) => {
     getPrivateCollectionByID,
     {
       id,
-    }
+    },
   );
 
   if (!collection) {

--- a/src/components/drawers/AccessDrawer.tsx
+++ b/src/components/drawers/AccessDrawer.tsx
@@ -37,6 +37,10 @@ const AccessContent = ({ onClose, collection }: Props) => {
 
     if (response.status === 200) {
       setCollectionAccessCookie(response.secret);
+
+      // Small delay to ensure cookie is set before reload
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
       reset();
       onClose(); // Close drawer first
       if (id && pathname === '/private') {

--- a/src/components/drawers/DownloadDrawer.tsx
+++ b/src/components/drawers/DownloadDrawer.tsx
@@ -183,7 +183,9 @@ const DownloadContent = ({ collection }: Props) => {
               </div>
               <p className='text-lg font-semibold'>File Retrieved!</p>
               <p className='text-sm text-gray-500'>
-                Your download has been prepared and sent to your browser.
+                Your download{' '}
+                {downloadSize !== null && `(~${formatBytes(downloadSize)}) `}has
+                been prepared and sent to your browser.
               </p>
               <button
                 onClick={() => setStep('download_parts')}

--- a/src/components/drawers/DownloadDrawer.tsx
+++ b/src/components/drawers/DownloadDrawer.tsx
@@ -5,6 +5,7 @@ import Input from '@/components/ui/form/Input';
 import CTAButton from '@/components/ui/CTA/CTAButton';
 import useFormState from '@/lib/hooks/useFormState';
 import useDownloadCollection from '@/lib/hooks/useDownloadCollection';
+import { formatBytes } from '@/lib/utils';
 import { COLLECTION } from '@/lib/types';
 import { FORMS } from '@/lib/Constants';
 import Progress from '@/components/ui/Progress';
@@ -50,6 +51,7 @@ const DownloadContent = ({ collection }: Props) => {
     total,
     progress,
     downloadStream,
+    downloadSize,
   } = useDownloadCollection(collection);
 
   const { initialValue, fields, rules } = FORMS.download;
@@ -146,7 +148,8 @@ const DownloadContent = ({ collection }: Props) => {
                   onClick={handleFullDownload}
                   className='w-full'
                 >
-                  Download Full Collection (Zip)
+                  Download Full Collection (Zip){' '}
+                  {downloadSize !== null && `(~${formatBytes(downloadSize)})`}
                 </CTAButton>
 
                 <CTAButton

--- a/src/components/header/MobileMenu.tsx
+++ b/src/components/header/MobileMenu.tsx
@@ -139,7 +139,7 @@ const AccessForm = ({ handleReroute }: { handleReroute: (r: any) => void }) => {
         errors={errors}
         handleChange={handleChange}
         setToken={setToken}
-        className='flex flex-col justify-center space-y-4 text-copy'
+        className='flex flex-col justify-center space-y-4 text-copy pb-8'
       >
         {response && (
           <span

--- a/src/components/ui/Drawer.tsx
+++ b/src/components/ui/Drawer.tsx
@@ -37,7 +37,7 @@ const Drawer = ({ isOpen, onClose, title, children, className }: Props) => {
       gsap.fromTo(
         backdropRef.current,
         { opacity: 0, autoAlpha: 0 },
-        { opacity: 1, autoAlpha: 1, duration: 0.3 }
+        { opacity: 1, autoAlpha: 1, duration: 0.3 },
       );
       gsap.fromTo(drawerRef.current, initialPos, {
         ...targetPos,
@@ -83,7 +83,7 @@ const Drawer = ({ isOpen, onClose, title, children, className }: Props) => {
   if (!isMounted) return null;
 
   return (
-    <div className='fixed inset-0 z-[99999] flex justify-end'>
+    <div className='fixed inset-0 z-99999 flex justify-end'>
       {/* Backdrop */}
       <div
         ref={backdropRef}
@@ -95,7 +95,7 @@ const Drawer = ({ isOpen, onClose, title, children, className }: Props) => {
       {/* Drawer Panel */}
       <div
         ref={drawerRef}
-        className={`relative w-full md:w-[400px] lg:w-[500px] h-[85vh] md:h-full mt-auto md:mt-0 bg-background shadow-2xl flex flex-col items-center ${
+        className={`relative w-full md:w-100 lg:w-125 h-[85dvh] md:h-full mt-auto md:mt-0 bg-background shadow-2xl flex flex-col items-center ${
           className || ''
         } rounded-t-2xl md:rounded-none`}
         role='dialog'

--- a/src/components/ui/Toast.tsx
+++ b/src/components/ui/Toast.tsx
@@ -28,7 +28,7 @@ const Toast = ({
       gsap.fromTo(
         toastRef.current,
         { opacity: 0, y: -20 },
-        { opacity: 1, y: 60, duration: 0.3 }
+        { opacity: 1, y: 60, duration: 0.3 },
       );
 
       if (autoClose) {
@@ -56,7 +56,7 @@ const Toast = ({
   };
 
   return (
-    <div className='flex flex-col gap-1 w-max fixed top-4 left-4 z-50 pointer-events-none'>
+    <div className='flex flex-col gap-1 w-max fixed top-4 left-4 z-100000 pointer-events-none'>
       {show && (
         <div
           ref={toastRef}

--- a/src/components/ui/form/Input.tsx
+++ b/src/components/ui/form/Input.tsx
@@ -1,4 +1,4 @@
-import { InputHTMLAttributes } from 'react';
+import { InputHTMLAttributes, useState, useEffect } from 'react';
 import { Label } from './Label';
 import { BaseFormFieldProps } from '@/lib/types';
 import { formatDateTimeForInput, setInputMinDate } from '@/lib/utils';
@@ -14,6 +14,13 @@ const Input = ({ className, ...props }: InputProps) => {
     : ('' as string);
 
   const isDate = dateTypes.includes(type!);
+  const [minDate, setMinDate] = useState<string | undefined>(undefined);
+
+  useEffect(() => {
+    if (isDate) {
+      setMinDate(setInputMinDate({ addDays: 1 }));
+    }
+  }, [isDate]);
 
   return (
     <div className='w-full flex flex-col space-y-0.5'>
@@ -24,7 +31,7 @@ const Input = ({ className, ...props }: InputProps) => {
         <input
           value={isDate ? formatDateTimeForInput(value) : value}
           className={`w-full text-primary bg-background border border-copy p-4 py-3 tracking-wider focus:outline-primary focus:border-none transition-all ${className}`}
-          min={isDate ? setInputMinDate({ addDays: 1 }) : undefined}
+          min={minDate}
           {...props}
         />
       </div>

--- a/src/components/ui/form/Input.tsx
+++ b/src/components/ui/form/Input.tsx
@@ -32,6 +32,11 @@ const Input = ({ className, ...props }: InputProps) => {
           value={isDate ? formatDateTimeForInput(value) : value}
           className={`w-full text-primary bg-background border border-copy p-4 py-3 tracking-wider focus:outline-primary focus:border-none transition-all ${className}`}
           min={minDate}
+          onFocus={(e) => {
+            // Scroll to center on mobile when keyboard opens
+            e.target.scrollIntoView({ behavior: 'smooth', block: 'center' });
+            props.onFocus?.(e);
+          }}
           {...props}
         />
       </div>

--- a/src/instrumentation.ts
+++ b/src/instrumentation.ts
@@ -1,0 +1,8 @@
+export async function register() {
+  if (process.env.NEXT_RUNTIME === 'nodejs') {
+    const { cleanupOrphanedFiles } = await import('@/lib/cleanup');
+    // Run cleanup without blocking startup completely, or await if fast enough.
+    // Given it's just checking specific files, it should be fast.
+    await cleanupOrphanedFiles();
+  }
+}

--- a/src/lib/cleanup.test.ts
+++ b/src/lib/cleanup.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { cleanupOrphanedFiles } from './cleanup';
+import fs from 'fs';
+import os from 'os';
+import path from 'path';
+
+// Mock fs and os
+vi.mock('fs', () => ({
+  default: {
+    promises: {
+      readdir: vi.fn(),
+      stat: vi.fn(),
+      rm: vi.fn(),
+    },
+  },
+}));
+
+vi.mock('os', () => ({
+  default: {
+    tmpdir: vi.fn(),
+  },
+}));
+
+describe('cleanupOrphanedFiles', () => {
+  const mockTmpDir = '/tmp/mock';
+  const now = Date.now();
+  const ONE_HOUR = 60 * 60 * 1000;
+
+  beforeEach(() => {
+    vi.clearAllMocks();
+    (os.tmpdir as any).mockReturnValue(mockTmpDir);
+  });
+
+  it('should delete old gen- directories and mogz_ zip files', async () => {
+    const files = [
+      'gen-old',
+      'mogz_old.zip',
+      'gen-new',
+      'mogz_new.zip',
+      'other.txt',
+    ];
+    (fs.promises.readdir as any).mockResolvedValue(files);
+
+    const oldStats = { mtimeMs: now - (ONE_HOUR + 1000) }; // 1h 1s old
+    const newStats = { mtimeMs: now - (ONE_HOUR - 1000) }; // 59m 59s old
+
+    (fs.promises.stat as any).mockImplementation((filePath: string) => {
+      if (filePath.includes('old')) return Promise.resolve(oldStats);
+      if (filePath.includes('new')) return Promise.resolve(newStats);
+      return Promise.resolve(oldStats); // Default old for other
+    });
+
+    await cleanupOrphanedFiles();
+
+    // Check deletions
+    expect(fs.promises.rm).toHaveBeenCalledTimes(2);
+    // Expect calls for old files
+    expect(fs.promises.rm).toHaveBeenCalledWith(
+      path.join(mockTmpDir, 'gen-old'),
+      expect.anything(),
+    );
+    expect(fs.promises.rm).toHaveBeenCalledWith(
+      path.join(mockTmpDir, 'mogz_old.zip'),
+      expect.anything(),
+    );
+
+    // Ensure new files and unrelated files are NOT deleted
+    expect(fs.promises.rm).not.toHaveBeenCalledWith(
+      path.join(mockTmpDir, 'gen-new'),
+      expect.anything(),
+    );
+    expect(fs.promises.rm).not.toHaveBeenCalledWith(
+      path.join(mockTmpDir, 'mogz_new.zip'),
+      expect.anything(),
+    );
+    expect(fs.promises.rm).not.toHaveBeenCalledWith(
+      path.join(mockTmpDir, 'other.txt'),
+      expect.anything(),
+    );
+  });
+
+  it('should handle errors gracefully during file check', async () => {
+    (fs.promises.readdir as any).mockResolvedValue(['gen-error']);
+    (fs.promises.stat as any).mockRejectedValue(new Error('Access denied'));
+
+    await cleanupOrphanedFiles();
+
+    // Should not crash and should not call rm
+    expect(fs.promises.rm).not.toHaveBeenCalled();
+  });
+});

--- a/src/lib/cleanup.ts
+++ b/src/lib/cleanup.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+export const cleanupOrphanedFiles = async () => {
+  const tmpDir = os.tmpdir();
+  const ONE_HOUR = 60 * 60 * 1000;
+  const now = Date.now();
+
+  try {
+    const files = await fs.promises.readdir(tmpDir);
+
+    const cleanupPromises = files.map(async (file) => {
+      const filePath = path.join(tmpDir, file);
+
+      // Check for targets: gen-* directories or mogz_*.zip files
+      const isGenDir = file.startsWith('gen-');
+      const isMogzZip = file.startsWith('mogz_') && file.endsWith('.zip');
+
+      if (!isGenDir && !isMogzZip) return;
+
+      try {
+        const stats = await fs.promises.stat(filePath);
+        const age = now - stats.mtimeMs;
+
+        if (age > ONE_HOUR) {
+          await fs.promises.rm(filePath, { recursive: true, force: true });
+          console.log(`[Cleanup] Deleted orphaned item: ${file}`);
+        }
+      } catch (err) {
+        // Ignore errors for individual files (e.g. permission issues or race conditions)
+        console.warn(`[Cleanup] Failed to check/delete ${file}:`, err);
+      }
+    });
+
+    await Promise.all(cleanupPromises);
+    console.log('[Cleanup] Startup cleanup check completed.');
+  } catch (error) {
+    console.error('[Cleanup] Error reading temp directory:', error);
+  }
+};

--- a/src/lib/hooks/useDownloadCollection.ts
+++ b/src/lib/hooks/useDownloadCollection.ts
@@ -270,7 +270,9 @@ const useDownloadCollection = ({
       link.style.display = 'none';
       document.body.appendChild(link);
       link.click();
-      document.body.removeChild(link);
+      setTimeout(() => {
+        document.body.removeChild(link);
+      }, 100);
 
       showToast('Download started...', 'success');
     } catch (e) {

--- a/src/lib/hooks/useDownloadCollection.ts
+++ b/src/lib/hooks/useDownloadCollection.ts
@@ -269,11 +269,8 @@ const useDownloadCollection = ({
       link.href = downloadUrl;
       link.style.display = 'none';
       document.body.appendChild(link);
-      // Ensure DOM update completes before click
-      requestAnimationFrame(() => {
-        link.click();
-        document.body.removeChild(link);
-      });
+      link.click();
+      document.body.removeChild(link);
 
       showToast('Download started...', 'success');
     } catch (e) {

--- a/src/lib/hooks/useDownloadCollection.ts
+++ b/src/lib/hooks/useDownloadCollection.ts
@@ -267,9 +267,13 @@ const useDownloadCollection = ({
       // A cleaner way for downloads that doesn't unload the app:
       const link = document.createElement('a');
       link.href = downloadUrl;
+      link.style.display = 'none';
       document.body.appendChild(link);
-      link.click();
-      document.body.removeChild(link);
+      // Ensure DOM update completes before click
+      requestAnimationFrame(() => {
+        link.click();
+        document.body.removeChild(link);
+      });
 
       showToast('Download started...', 'success');
     } catch (e) {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -227,8 +227,9 @@ export const setCollectionAccessCookie = (secret: string) => {
     secure: isSecure,
     sameSite: 'Lax',
     path: '/',
-    expires: 1,
+    expires: 1, // 1 day
   });
+  console.log(`[Cookie] Set collectionAccess (Secure: ${isSecure})`);
 };
 
 type MetadataOverwrites = {

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -222,9 +222,10 @@ export const setInputMinDate = (params?: SetInputMinDateParams): string => {
 };
 
 export const setCollectionAccessCookie = (secret: string) => {
+  const isSecure = window.location.protocol === 'https:';
   Cookies.set('collectionAccess', secret, {
-    secure: true,
-    sameSite: 'Strict',
+    secure: isSecure,
+    sameSite: 'Lax',
   });
 };
 
@@ -239,7 +240,7 @@ type MetadataOverwrites = {
 
 export const getPageMetadata = (
   name: string,
-  overwrites?: MetadataOverwrites
+  overwrites?: MetadataOverwrites,
 ): Metadata => {
   const pageMetaData = METADATA.get(name);
   const twitterHandle = SOCIALS.find((s) => s.label === 'Twitter')
@@ -335,4 +336,16 @@ export const getPageMetadata = (
   }
 
   return baseMetadata;
+};
+
+export const formatBytes = (bytes: number | null | undefined, decimals = 2) => {
+  if (bytes === null || bytes === undefined || bytes === 0) return '0 Bytes';
+
+  const k = 1024;
+  const dm = decimals < 0 ? 0 : decimals;
+  const sizes = ['Bytes', 'KB', 'MB', 'GB', 'TB', 'PB', 'EB', 'ZB', 'YB'];
+
+  const i = Math.floor(Math.log(bytes) / Math.log(k));
+
+  return parseFloat((bytes / Math.pow(k, i)).toFixed(dm)) + ' ' + sizes[i];
 };

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -226,6 +226,8 @@ export const setCollectionAccessCookie = (secret: string) => {
   Cookies.set('collectionAccess', secret, {
     secure: isSecure,
     sameSite: 'Lax',
+    path: '/',
+    expires: 1,
   });
 };
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -225,11 +225,11 @@ export const setCollectionAccessCookie = (secret: string) => {
   const isSecure = window.location.protocol === 'https:';
   Cookies.set('collectionAccess', secret, {
     secure: isSecure,
-    sameSite: 'Strict',
+    sameSite: 'Lax',
     path: '/',
   });
   console.log(
-    `[Cookie] Set collectionAccess (Secure: ${isSecure}, SameSite: Strict, Path: /)`,
+    `[Cookie] Set collectionAccess (Secure: ${isSecure}, SameSite: Lax, Path: /)`,
   );
 };
 

--- a/src/lib/utils.ts
+++ b/src/lib/utils.ts
@@ -225,11 +225,12 @@ export const setCollectionAccessCookie = (secret: string) => {
   const isSecure = window.location.protocol === 'https:';
   Cookies.set('collectionAccess', secret, {
     secure: isSecure,
-    sameSite: 'Lax',
+    sameSite: 'Strict',
     path: '/',
-    expires: 1, // 1 day
   });
-  console.log(`[Cookie] Set collectionAccess (Secure: ${isSecure})`);
+  console.log(
+    `[Cookie] Set collectionAccess (Secure: ${isSecure}, SameSite: Strict, Path: /)`,
+  );
 };
 
 type MetadataOverwrites = {


### PR DESCRIPTION
<!-- greptile_comment -->

<h2>Greptile Overview</h2>

<h3>Greptile Summary</h3>

This PR refactors the download system to fix streaming issues and add size estimation capabilities. The major changes include:

- **Streaming Architecture**: Refactored `download/stream/route.ts` to simultaneously stream zip to client and cache using `PassThrough`, eliminating the blocking generation step and improving user experience
- **Size Estimation API**: Added new `download/info/route.ts` endpoint that uses Fisher-Yates sampling of ~15 images with HEAD requests to calculate a size correction ratio, providing accurate download size estimates
- **Startup Cleanup**: Added `instrumentation.ts` and `cleanup.ts` to automatically clean up orphaned temp files (gen-* directories and mogz_*.zip files older than 1 hour) on server startup
- **GET Support**: Added GET method support to stream endpoint alongside POST, enabling simpler direct link downloads
- **Cookie Improvements**: Changed `SameSite` from `Strict` to `Lax` with conditional secure flag for better localhost development experience

**Key improvements:**
- Stream starts immediately instead of waiting for full zip generation
- Cache writes happen in background without blocking response
- Proper cleanup of orphaned temp files from crashes/interrupts
- More accurate size predictions using real CDN measurements

**Issues found:**
- One logic issue with stream backpressure handling after archiver takes ownership
- Three syntax issues with Tailwind CSS classes in UI components (missing brackets for arbitrary values)

<h3>Confidence Score: 4/5</h3>

- This PR is safe to merge after fixing the syntax issues in UI components
- The core download streaming refactor is well-implemented with proper error handling and cleanup. The new size estimation endpoint uses good sampling techniques. The Tailwind syntax errors in Drawer.tsx and Toast.tsx need fixing but won't cause runtime errors. The logic issue with stream backpressure may not cause problems in practice since archiver handles streams appropriately, but should be verified.
- src/components/ui/Drawer.tsx and src/components/ui/Toast.tsx require syntax fixes for Tailwind classes

<h3>Important Files Changed</h3>




| Filename | Overview |
|----------|----------|
| src/lib/cleanup.ts | New cleanup utility added to remove orphaned temp files older than 1 hour |
| src/instrumentation.ts | Added startup cleanup on Node.js runtime initialization |
| src/app/api/download/info/route.ts | New endpoint using Fisher-Yates sampling to calculate corrected download size with real HEAD requests |
| src/app/api/download/stream/route.ts | Refactored to stream simultaneously to response and cache, with GET support and improved error handling |
| src/components/ui/Drawer.tsx | Changed z-index and width classes to arbitrary values, updated viewport height to dvh |

</details>



<h3>Sequence Diagram</h3>

```mermaid
sequenceDiagram
    participant Client
    participant Hook as useDownloadCollection
    participant InfoAPI as /api/download/info
    participant StreamAPI as /api/download/stream
    participant Sanity as Sanity CMS
    participant CDN as cdn.sanity.io
    participant Cache as Temp Cache

    Client->>Hook: downloadStream(email)
    Hook->>Hook: Build GET URL params
    Hook->>Hook: Create hidden <a> element
    Hook->>Client: Trigger link.click()
    Client->>StreamAPI: GET /api/download/stream?params
    
    StreamAPI->>StreamAPI: Extract & validate params
    StreamAPI->>StreamAPI: Check auth (private collections)
    StreamAPI->>Sanity: Fetch collection metadata & items
    Sanity-->>StreamAPI: Return {title, items[]}
    
    StreamAPI->>StreamAPI: Calculate cache key (MD5 hash)
    StreamAPI->>Cache: Check cache exists & valid?
    
    alt Cache Hit
        Cache-->>StreamAPI: Return cached zip file
        StreamAPI-->>Client: Stream cached file
    else Cache Miss
        StreamAPI->>StreamAPI: Create temp directory (mkdtemp)
        StreamAPI->>StreamAPI: Create archive with PassThrough
        StreamAPI->>StreamAPI: Pipe archive to response & file
        
        loop For each batch (3 images)
            par Fetch images in parallel
                StreamAPI->>CDN: Fetch image URL
                CDN-->>StreamAPI: Return image stream
            end
            StreamAPI->>StreamAPI: Append valid streams to archive
            StreamAPI->>StreamAPI: Wait for last stream to finish
        end
        
        StreamAPI->>StreamAPI: Finalize archive
        StreamAPI-->>Client: Stream zip in real-time
        
        Note over StreamAPI,Cache: Background cache write
        StreamAPI->>Cache: Rename temp to cache (3 retries)
        StreamAPI->>Cache: Cleanup temp directory
    end
    
    Note over Client: Browser downloads zip file
    
    Note over InfoAPI: Separate endpoint for size calculation
    Client->>InfoAPI: POST /api/download/info
    InfoAPI->>Sanity: Fetch collection items
    InfoAPI->>InfoAPI: Fisher-Yates sample ~15 images
    loop For each sample
        InfoAPI->>CDN: HEAD request for actual size
        CDN-->>InfoAPI: content-length header
    end
    InfoAPI->>InfoAPI: Calculate size correction ratio
    InfoAPI->>InfoAPI: Apply ratio to total size estimate
    InfoAPI-->>Client: Return {size, count}
```

<!-- greptile_other_comments_section -->

<!-- /greptile_comment -->